### PR TITLE
MONIT-10728 Removing event counters from lambda wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,8 @@ The Lambda wrapper sends the following standard lambda metrics to wavefront:
 | Metric Name                       |  Type              | Description                                                             |
 | ----------------------------------|:------------------:| ----------------------------------------------------------------------- |
 | aws.lambda.wf.invocations.count   | Delta Counter      | Count of number of lambda function invocations aggregated at the server.|
-| aws.lambda.wf.invocation_event.count   |  Counter      | Count of number of lambda function invocations.|
 | aws.lambda.wf.errors.count        | Delta Counter      | Count of number of errors aggregated at the server.                     |
-| aws.lambda.wf.error_event.count        |  Counter      | Count of number of errors.                     |
 | aws.lambda.wf.coldstarts.count    | Delta Counter      | Count of number of cold starts aggregated at the server.                |
-| aws.lambda.wf.coldstart_event.count| Counter           | Count of number of cold starts.                                         |
 | aws.lambda.wf.duration.value      | Gauge              | Execution time of the Lambda handler function in milliseconds.          |
 
 The Lambda wrapper adds the following point tags to all metrics sent to wavefront:

--- a/reporter.go
+++ b/reporter.go
@@ -30,28 +30,22 @@ func updateGaugeFloat64(gauge metrics.GaugeFloat64, value float64, report bool) 
 func registerStandardLambdaMetrics() {
 	// Register cold start counter.
 	csCounter = metrics.NewCounter()
-	csCounterName := wavefront.DeltaCounterName(getStandardLambdaMetricName("coldstarts", false))
+	csCounterName := wavefront.DeltaCounterName(getStandardLambdaMetricName("coldstarts"))
 	wavefront.RegisterMetric(csCounterName, csCounter, nil)
-	csEventCounter = metrics.NewCounter()
-	wavefront.RegisterMetric(getStandardLambdaMetricName("coldstart", true), csEventCounter, nil)
 
 	// Register invocations counter.
 	invocationsCounter = metrics.NewCounter()
-	invocationsCounterName := wavefront.DeltaCounterName(getStandardLambdaMetricName("invocations", false))
+	invocationsCounterName := wavefront.DeltaCounterName(getStandardLambdaMetricName("invocations"))
 	wavefront.RegisterMetric(invocationsCounterName, invocationsCounter, nil)
-	invocationEventCounter = metrics.NewCounter()
-	wavefront.RegisterMetric(getStandardLambdaMetricName("invocation", true), invocationEventCounter, nil)
 
 	// Register Error counter
 	errCounter = metrics.NewCounter()
-	errCounterName := wavefront.DeltaCounterName(getStandardLambdaMetricName("errors", false))
+	errCounterName := wavefront.DeltaCounterName(getStandardLambdaMetricName("errors"))
 	wavefront.RegisterMetric(errCounterName, errCounter, nil)
-	errEventCounter = metrics.NewCounter()
-	wavefront.RegisterMetric(getStandardLambdaMetricName("error", true), errEventCounter, nil)
 
 	// Register duration gauge
 	durationGauge = metrics.NewGaugeFloat64()
-	wavefront.RegisterMetric(getStandardLambdaMetricName("duration", false), durationGauge, nil)
+	wavefront.RegisterMetric(getStandardLambdaMetricName("duration"), durationGauge, nil)
 }
 
 // Method to send all metrics in the registry to wavefront.
@@ -101,12 +95,8 @@ func reportMetrics(ctx context.Context) {
 // getStandardLambdaMetricName("invocation", true) returns "aws.lambda.wf.invocation_event"
 // getStandardLambdaMetricName("invocations", false) returns "aws.lambda.wf.invocations"
 
-func getStandardLambdaMetricName(metric string, isEvent bool) string {
+func getStandardLambdaMetricName(metric string) string {
 	const metric_prefix string = "aws.lambda.wf."
-	const metric_event_suffix string = "_event"
-	if isEvent {
-		return strings.Join([]string{metric_prefix, metric, metric_event_suffix}, "")
-	}
 	return strings.Join([]string{metric_prefix, metric}, "")
 }
 

--- a/wflambda_test.go
+++ b/wflambda_test.go
@@ -6,13 +6,8 @@ import (
 )
 
 func TestGetStandardLambdaMetricName(t *testing.T) {
-	actualName := getStandardLambdaMetricName("customMetric", true)
-	expectedName := "aws.lambda.wf.customMetric_event"
-	if actualName != expectedName {
-		t.Error("Metric names don't match ", expectedName, actualName)
-	}
-	actualName = getStandardLambdaMetricName("customMetrics", false)
-	expectedName = "aws.lambda.wf.customMetrics"
+	actualName := getStandardLambdaMetricName("customMetrics")
+	expectedName := "aws.lambda.wf.customMetrics"
 	if actualName != expectedName {
 		t.Error("Metric names don't match ", expectedName, actualName)
 	}

--- a/wrapper.go
+++ b/wrapper.go
@@ -20,11 +20,8 @@ var (
 	handlerValue              reflect.Value
 	coldStart                 = true
 	csCounter                 metrics.Counter
-	csEventCounter            metrics.Counter
 	invocationsCounter        metrics.Counter
-	invocationEventCounter    metrics.Counter
 	errCounter                metrics.Counter
-	errEventCounter           metrics.Counter
 	durationGauge             metrics.GaugeFloat64
 )
 
@@ -61,11 +58,9 @@ func lambdaHandlerWrapper(ctx context.Context, payload json.RawMessage) (respons
 			err = e
 			// Set error counters
 			incrementCounter(errCounter, 1, reportStandardMetrics)
-			incrementCounter(errEventCounter, 1, reportStandardMetrics)
 		} else if lambdaHandlerError != nil {
 			// Set error counters
 			incrementCounter(errCounter, 1, reportStandardMetrics)
-			incrementCounter(errEventCounter, 1, reportStandardMetrics)
 		}
 		reportMetrics(ctx)
 		metrics.DefaultRegistry.UnregisterAll()
@@ -94,12 +89,10 @@ func lambdaHandlerWrapper(ctx context.Context, payload json.RawMessage) (respons
 	if coldStart {
 		// Set cold start counter
 		incrementCounter(csCounter, 1, reportStandardMetrics)
-		incrementCounter(csEventCounter, 1, reportStandardMetrics)
 		coldStart = false
 	}
 	// Set invocations counter.
 	incrementCounter(invocationsCounter, 1, reportStandardMetrics)
-	incrementCounter(invocationEventCounter, 1, reportStandardMetrics)
 	start := time.Now()
 	lambdaResponse := handlerValue.Call(args)
 	executionDuration := time.Since(start)


### PR DESCRIPTION
Removing event counters from lambda wrappers as they are redundant , given the existence of delta counter metrics.

Please review. Cc @vikramraman 

Thank you,
Anil